### PR TITLE
add `git` to required binaries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ struct NixShellOutput {
 }
 
 fn minimal_essential_path() -> OsString {
-    let required_binaries = ["nix-shell", "tar", "gzip"];
+    let required_binaries = ["nix-shell", "tar", "gzip", "git"];
 
     let which_dir = |binary: &&str| -> Option<PathBuf> {
         std::env::var_os("PATH")


### PR DESCRIPTION
needed for `builtins.fetchgit`

I don't know if this is cached correctly, it does seem to be invalidated properly when local repositories change, but it might not ever see remote updates