### PR TITLE
Add macOS support.

### DIFF
--- a/nix-trace/test.sh
+++ b/nix-trace/test.sh
@@ -2,13 +2,13 @@
 
 run() {
 	rm -f test-tmp/log
-	LD_PRELOAD=$PWD/build/trace-nix.so TRACE_NIX=test-tmp/log \
+	DYLD_INSERT_LIBRARIES=$PWD/build/trace-nix.so LD_PRELOAD=$PWD/build/trace-nix.so TRACE_NIX=test-tmp/log \
 		nix-shell --run : -p -- "$@" 2>/dev/null
 }
 
 run_without_p() {
 	rm -f test-tmp/log
-	LD_PRELOAD=$PWD/build/trace-nix.so TRACE_NIX=test-tmp/log \
+	DYLD_INSERT_LIBRARIES=$PWD/build/trace-nix.so LD_PRELOAD=$PWD/build/trace-nix.so TRACE_NIX=test-tmp/log \
 		nix-shell --run : -- "$@" 2>/dev/null
 }
 

--- a/nix-trace/trace-nix.c
+++ b/nix-trace/trace-nix.c
@@ -6,7 +6,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,16 +15,34 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-static pthread_mutex_t mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 static FILE *log_f = NULL;
 static const char *pwd = NULL;
+
+#ifdef __APPLE__
+
+struct dyld_interpose {
+	const void * replacement;
+	const void * replacee;
+};
+
+#define WRAPPER(RET, FUN) static RET _cns_wrapper_##FUN
+#define REAL(FUN) FUN
+#define DEF_WRAPPER(FUN) \
+	__attribute__((used)) static struct dyld_interpose _cns_interpose_##FUN \
+	__attribute__((section("__DATA,__interpose"))) = { &_cns_wrapper_##FUN, &FUN };
+
+#else /* __APPLE__ */
 
 static int (*real___lxstat)(int ver, const char *path, struct stat *buf) = NULL;
 static int (*real_open)(const char *path, int flags, ...) = NULL;
 static DIR *(*real_opendir)(const char *name) = NULL;
 
+#define WRAPPER(RET, FUN) RET FUN
 #define REAL(FUN) \
 	(real_##FUN == NULL ? (real_##FUN = dlsym(RTLD_NEXT, #FUN)) : real_##FUN)
+#define DEF_WRAPPER(FUN)
+
+#endif /* __APPLE__ */
 
 #define FATAL() \
 	do { \
@@ -36,8 +53,36 @@ static DIR *(*real_opendir)(const char *name) = NULL;
 
 #define LEN 16
 
+// Locks
+
+#ifdef __APPLE__
+
+#include <dispatch/dispatch.h>
+static dispatch_semaphore_t print_mutex;
+static dispatch_semaphore_t buf_mutex;
+#define INIT_MUTEX(MUTEX) \
+	MUTEX = dispatch_semaphore_create(1)
+#define LOCK(MUTEX) \
+	dispatch_semaphore_wait(MUTEX, DISPATCH_TIME_FOREVER)
+#define UNLOCK(MUTEX) \
+	dispatch_semaphore_signal(MUTEX)
+
+#else /* __APPLE__ */
+
+#include <pthread.h>
+static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t buf_mutex = PTHREAD_MUTEX_INITIALIZER;
+#define INIT_MUTEX(MUTEX)
+#define LOCK(MUTEX) \
+	pthread_mutex_lock(&MUTEX)
+#define UNLOCK(MUTEX) \
+	pthread_mutex_unlock(&MUTEX)
+
+#endif /* __APPLE__ */
+
 // Predeclarations
 
+static void print_stat(int result, const char *path, struct stat *sb);
 static void convert_digest(char [static LEN*2+1], const uint8_t [static LEN]);
 static int enable(const char *);
 static void hash_dir(char [static LEN*2+1], DIR *);
@@ -47,10 +92,65 @@ static int strcmp_qsort(const void *, const void *);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef __APPLE__
+
+/*	$OpenBSD: reallocarray.c,v 1.3 2015/09/13 08:31:47 guenther Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+static void *reallocarray(void *optr, size_t nmemb, size_t size) {
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+		nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+
+static const char *get_current_dir_name() {
+	char *buf = NULL;
+	size_t bufsize = 64 * sizeof(char);
+	do {
+		buf = realloc(buf, bufsize);
+		if (buf == NULL)
+			FATAL();
+		if (getcwd(buf, bufsize))
+		return buf;
+		bufsize *= 2;
+	} while (errno == ERANGE);
+	FATAL();
+}
+#endif /* __APPLE__ */
+
 static void __attribute__((constructor)) init() {
-	// Remove ourselves from LD_PRLOAD. We do not want to log child processes.
+	// Remove ourselves from LD_PRELOAD and DYLD_INSERT_LIBRARIES. We do not want to log child processes.
 	// TODO: use `ld.so --preload` instead
 	unsetenv("LD_PRELOAD");
+	unsetenv("DYLD_INSERT_LIBRARIES");
 
 	const char *fname = getenv("TRACE_NIX");
 	if (fname != NULL) {
@@ -65,42 +165,32 @@ static void __attribute__((constructor)) init() {
 			FATAL();
 	}
 	unsetenv("TRACE_NIX");
+
+	INIT_MUTEX(print_mutex);
+	INIT_MUTEX(buf_mutex);
 }
 
-int __lxstat(int ver, const char *path, struct stat *sb) {
-	static char *buf = NULL;
-	static off_t buf_len = 0;
+#ifdef __APPLE__
 
-	int result = REAL(__lxstat)(ver, path, sb);
-
-	if (enable(path)) {
-		if (result != 0) {
-			print_log('s', path, "-");
-		} else if (S_ISLNK(sb->st_mode)) {
-			pthread_mutex_lock(&mutex);
-			if (buf_len < sb->st_size + 2) {
-				buf_len = sb->st_size + 2;
-				buf = realloc(buf, buf_len);
-				if (buf == NULL)
-					FATAL();
-			}
-			ssize_t link_len = readlink(path, buf+1, sb->st_size);
-			if (link_len < 0 || link_len != sb->st_size)
-				FATAL();
-			buf[0] = 'l';
-			buf[sb->st_size+1] = 0;
-			print_log('s', path, buf);
-			pthread_mutex_unlock(&mutex);
-		} else if (S_ISDIR(sb->st_mode)) {
-			print_log('s', path, "d");
-		} else {
-			print_log('s', path, "+");
-		}
-	}
+WRAPPER(int, lstat)(const char *path, struct stat *sb) {
+	int result = REAL(lstat)(path, sb);
+	print_stat(result, path, sb);
 	return result;
-} 
+}
+DEF_WRAPPER(lstat);
 
-int open(const char *path, int flags, ...) {
+#else /* __APPLE__ */
+
+WRAPPER(int, __lxstat)(int ver, const char *path, struct stat *sb) {
+	int result = REAL(__lxstat)(ver, path, sb);
+	print_stat(result, path, sb);
+	return result;
+}
+DEF_WRAPPER(__lxstat)
+
+#endif /* __APPLE__ */
+
+WRAPPER(int, open)(const char *path, int flags, ...) {
 	va_list args;
 	va_start(args, flags);
 	int mode = va_arg(args, int);
@@ -120,8 +210,9 @@ int open(const char *path, int flags, ...) {
 
 	return fd;
 }
+DEF_WRAPPER(open)
 
-DIR *opendir(const char *path) {
+WRAPPER(DIR *, opendir)(const char *path) {
 	DIR *dirp = REAL(opendir)(path);
 	if (enable(path)) {
 		if (dirp == NULL) {
@@ -134,6 +225,7 @@ DIR *opendir(const char *path) {
 	}
 	return dirp;
 }
+DEF_WRAPPER(opendir)
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -164,8 +256,38 @@ static int enable(const char *path) {
 	return 1;
 }
 
+static void print_stat(int result, const char *path, struct stat *sb) {
+	static char *buf = NULL;
+	static off_t buf_len = 0;
+
+	if (enable(path)) {
+		if (result != 0) {
+			print_log('s', path, "-");
+		} else if (S_ISLNK(sb->st_mode)) {
+			LOCK(buf_mutex);
+			if (buf_len < sb->st_size + 2) {
+				buf_len = sb->st_size + 2;
+				buf = realloc(buf, buf_len);
+				if (buf == NULL)
+					FATAL();
+			}
+			ssize_t link_len = readlink(path, buf+1, sb->st_size);
+			if (link_len < 0 || link_len != sb->st_size)
+				FATAL();
+			buf[0] = 'l';
+			buf[sb->st_size+1] = 0;
+			print_log('s', path, buf);
+						UNLOCK(buf_mutex);
+		} else if (S_ISDIR(sb->st_mode)) {
+			print_log('s', path, "d");
+		} else {
+			print_log('s', path, "+");
+		}
+	}
+}
+
 static void print_log(char op, const char *path, const char *result) {
-	pthread_mutex_lock(&mutex);
+	LOCK(print_mutex);
 	fprintf(
 		log_f,
 		"%c" "%s%s" "%s%c" "%s%c",
@@ -175,7 +297,7 @@ static void print_log(char op, const char *path, const char *result) {
 		result, (char)0
 	);
 	fflush(log_f);
-	pthread_mutex_unlock(&mutex);
+	UNLOCK(print_mutex);
 }
 
 static void hash_file(char digest_s[static LEN*2+1], int fd) {

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let main = import ./default.nix { inherit pkgs; };
 in with pkgs;
 mkShell {
   buildInputs = main.buildInputs ++ main.nativeBuildInputs
-    ++ [ cargo-edit niv nixfmt rustfmt shellcheck ];
+    ++ [ cargo-edit niv nixfmt rustfmt shellcheck time ];
   inherit (main) BLAKE3_CSRC;
   CNS_IN_NIX_SHELL = "1";
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ struct NixShellOutput {
 }
 
 fn minimal_essential_path() -> OsString {
-    let required_binaries = ["tar", "gzip", "git"];
+    let required_binaries = ["tar", "gzip", "git", "nix-shell", "rm"];
 
     fn which_dir(binary: &&str) -> Option<PathBuf> {
         std::env::var_os("PATH")
@@ -232,6 +232,7 @@ fn run_nix_shell(inp: &NixShellInput) -> NixShellOutput {
             .env_clear()
             .envs(&inp.env)
             .env("LD_PRELOAD", env!("CNS_TRACE_NIX_SO"))
+            .env("DYLD_INSERT_LIBRARIES", env!("CNS_TRACE_NIX_SO"))
             .env("TRACE_NIX", trace_file.path())
             .stdin(Stdio::null())
             .status()


### PR DESCRIPTION
Using dyld interposing as documented in:
https://opensource.apple.com/source/dyld/dyld-97.1/include/mach-o/dyld-interposing.h.auto.html
Following the example here:
https://github.com/NixOS/nixpkgs/blob/9d452bdebedb1c47adaabd40e61a742f9f07b54c/pkgs/build-support/libredirect/libredirect.c

I've unconditionally passed both `DYLD_INSERT_LIBRARIES` and `LD_PRELOAD`, reasoning that whichever runtime linker we're using will ignore the environment variable it doesn't use, and we'll unset both in the initializer anyway.